### PR TITLE
Update github.com/hkwi/nlgo revision

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -5,7 +5,7 @@
   branch = "master"
   name = "github.com/hkwi/nlgo"
   packages = ["."]
-  revision = "a84bdcfa49f5f8947a64e62adf6a41181de2e11a"
+  revision = "dbae43f4fc47bf868bca3cc3c1ea2954c2059842"
 
 [[projects]]
   name = "github.com/hnakamur/ltsvlog"


### PR DESCRIPTION
[Guard familyIds with lock in GenlHub.Family by hnakamur · Pull Request #3 · hkwi/nlgo](https://github.com/hkwi/nlgo/pull/3) がマージされたので、dep の設定ファイルを更新するプルリクです。

コマンドから更新しようとしたのですが以下のエラーが出たので Gopkg.lock を手で修正しています。

```
# dep ensure -update
ensure Solve(): No versions of github.com/hkwi/nlgo met constraints:
        master: Unable to update checked out version: fatal: reference is not a tree: dbae43f4fc47bf868bca3cc3c1ea2954c2059842
```
